### PR TITLE
Feature/adding get all invoices endpoint

### DIFF
--- a/src/Invoice_Gen.Domain/InvoiceRepository.cs
+++ b/src/Invoice_Gen.Domain/InvoiceRepository.cs
@@ -3,27 +3,6 @@ using Microsoft.Extensions.Logging;
 
 namespace Invoice_Gen.Domain;
 
-public class LineItemRepository : ILineItemRepository
-{
-    private readonly IDbContext _dbContext;
-    private readonly ILogger<LineItemRepository> _logger;
-
-    public LineItemRepository(ILogger<LineItemRepository> logger, IDbContext dbContext)
-    {
-        _logger = logger;
-        _dbContext = dbContext;
-    }
-
-    public List<LineItem> GetAll()
-    {
-        using (_logger.BeginScope("{RepositoryName} - getting all {RecordName} records",
-                   nameof(LineItemRepository), nameof(LineItem)))
-        {
-            return _dbContext.LineItems.ToList();
-        }
-    }
-}
-
 public class InvoiceRepository : IInvoiceRepository
 {
     private readonly IDbContext _dbContext;

--- a/src/Invoice_Gen.Domain/LineItemRepository.cs
+++ b/src/Invoice_Gen.Domain/LineItemRepository.cs
@@ -1,0 +1,25 @@
+﻿using Invoice_Gen.Domain.Models;
+using Microsoft.Extensions.Logging;
+
+namespace Invoice_Gen.Domain;
+
+public class LineItemRepository : ILineItemRepository
+{
+    private readonly IDbContext _dbContext;
+    private readonly ILogger<LineItemRepository> _logger;
+
+    public LineItemRepository(ILogger<LineItemRepository> logger, IDbContext dbContext)
+    {
+        _logger = logger;
+        _dbContext = dbContext;
+    }
+
+    public List<LineItem> GetAll()
+    {
+        using (_logger.BeginScope("{RepositoryName} - getting all {RecordName} records",
+                   nameof(LineItemRepository), nameof(LineItem)))
+        {
+            return _dbContext.LineItems.ToList();
+        }
+    }
+}

--- a/src/Invoice_Gen.ViewModels/VersionResponse.cs
+++ b/src/Invoice_Gen.ViewModels/VersionResponse.cs
@@ -1,5 +1,8 @@
-﻿namespace Invoice_Gen.ViewModels;
+﻿using System.Diagnostics.CodeAnalysis;
 
+namespace Invoice_Gen.ViewModels;
+
+[ExcludeFromCodeCoverage]
 public class VersionResponse
 {
     public string VersionNumber { get; init; } = "0.0.0.0";

--- a/src/Invoice_Gen.WebApi/Controllers/ClientsController.cs
+++ b/src/Invoice_Gen.WebApi/Controllers/ClientsController.cs
@@ -18,7 +18,7 @@ public class ClientsController : ControllerBase
     }
 
     /// <summary>
-    /// Returns a new instance of <see cref="ClientViewModel"/>
+    /// Returns all clients in the system in a list of <see cref="ClientViewModel"/>
     /// </summary>
     /// <returns>
     /// A list of <see cref="ClientViewModel"/> instances with some default data

--- a/src/Invoice_Gen.WebApi/Controllers/InvoiceController.cs
+++ b/src/Invoice_Gen.WebApi/Controllers/InvoiceController.cs
@@ -18,6 +18,25 @@ public class InvoiceController : ControllerBase
     }
 
     /// <summary>
+    /// Returns all invoices in the system in a list of <see cref="InvoiceViewModel"/>
+    /// </summary>
+    /// <returns>
+    /// A list of <see cref="InvoiceViewModel"/> instances with some default data
+    /// </returns>
+    [HttpGet(Name = "GetInvoices")]
+    [ProducesResponseType(typeof(List<InvoiceViewModel>), StatusCodes.Status200OK)]
+    public IActionResult Get()
+    {
+        using (_logger.BeginScope("Getting all invoices"))
+        {
+            var invoices = _invoiceService.GetInvoices();
+
+            _logger.LogInformation("Returning list of {InvoiceViewModel}", typeof(InvoiceViewModel));
+            return new OkObjectResult(invoices);
+        }
+    }
+    
+    /// <summary>
     /// Gets the instance of <see cref="InvoiceViewModel"/> for the provided <paramref name="invoiceId"/>
     /// </summary>
     /// <returns>
@@ -25,7 +44,7 @@ public class InvoiceController : ControllerBase
     /// or a <see cref="StatusCodes.Status404NotFound"/> if one cannot be found
     /// </returns>
     [HttpGet("{invoiceId}", Name = "GetInvoiceById")]
-    [ProducesResponseType(typeof(ClientViewModel), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(InvoiceViewModel), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public IActionResult GetInvoiceById(int invoiceId)
     {
@@ -55,7 +74,7 @@ public class InvoiceController : ControllerBase
     [HttpPut]
     [ProducesResponseType(typeof(int), StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public async Task<IActionResult> CreateClient(InvoiceCreateModel newInvoice)
+    public async Task<IActionResult> CreateInvoice(InvoiceCreateModel newInvoice)
     {
         using (_logger.BeginScope("Request to create new client Invoice for client {ClientId} received",
                    newInvoice.ClientId))

--- a/src/Invoice_Gen.WebApi/Controllers/InvoiceController.cs
+++ b/src/Invoice_Gen.WebApi/Controllers/InvoiceController.cs
@@ -35,7 +35,7 @@ public class InvoiceController : ControllerBase
             return new OkObjectResult(invoices);
         }
     }
-    
+
     /// <summary>
     /// Gets the instance of <see cref="InvoiceViewModel"/> for the provided <paramref name="invoiceId"/>
     /// </summary>

--- a/src/Invoice_Gen.WebApi/Invoice_Gen.WebApi.csproj
+++ b/src/Invoice_Gen.WebApi/Invoice_Gen.WebApi.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
-    <VersionPrefix>0.0.0.6-beta</VersionPrefix>
+    <VersionPrefix>0.0.0.7-beta</VersionPrefix>
     <AssemblyName>Invoice_Gen.WebApi</AssemblyName>
     <PackageId>Invoice_Gen.WebApi</PackageId>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/src/Invoice_Gen.WebApi/Services/ClientService.cs
+++ b/src/Invoice_Gen.WebApi/Services/ClientService.cs
@@ -26,7 +26,7 @@ public class ClientService : IClientService
                 nameof(ClientViewModel), typeof(ClientNameViewModelMapper));
             var returnData = all.Select(c => _clientViewModelMapper.Convert(c)).ToList();
 
-            _logger.LogInformation("Returning {count} of {ClientNameViewModel} instances", returnData.Count(),
+            _logger.LogInformation("Returning {count} of {ClientNameViewModel} instances", returnData.Count,
                 nameof(ClientViewModel));
             return returnData;
         }

--- a/src/Invoice_Gen.WebApi/Services/IInvoiceService.cs
+++ b/src/Invoice_Gen.WebApi/Services/IInvoiceService.cs
@@ -2,6 +2,7 @@
 
 public interface IInvoiceService
 {
+    List<InvoiceViewModel> GetInvoices();
     InvoiceViewModel? GetById(int id);
     Task<int> CreateNewInvoice(InvoiceCreateModel newInvoice);
 }

--- a/src/Invoice_Gen.WebApi/Services/InvoiceService.cs
+++ b/src/Invoice_Gen.WebApi/Services/InvoiceService.cs
@@ -20,6 +20,24 @@ public class InvoiceService : IInvoiceService
         _invoiceCreateModelMapper = invoiceCreateModelMapper;
     }
 
+    public List<InvoiceViewModel> GetInvoices()
+    {
+        using (_logger.BeginScope("{InvoiceService} getting all clients", nameof(InvoiceService)))
+        {
+            var all = _invoiceRepository.GetAll();
+
+            _logger.LogInformation("Retrieved {Count} {InvoiceModel}", all.Count, nameof(Invoice));
+
+            _logger.LogInformation("Converting to List of {InvoiceViewModel} using {Mapper}",
+                nameof(InvoiceViewModel), typeof(InvoiceViewModelMapper));
+            var returnData = all.Select(c => _invoiceViewModelMapper.Convert(c)).ToList();
+
+            _logger.LogInformation("Returning {count} of {InvoiceViewModel} instances", returnData.Count,
+                nameof(InvoiceViewModel));
+            return returnData;
+        }
+    }
+    
     public InvoiceViewModel? GetById(int id)
     {
         using (_logger.BeginScope("{InvoiceService} getting invoice record for {ID}", nameof(InvoiceService), id))

--- a/src/Invoice_Gen.WebApi/Services/InvoiceService.cs
+++ b/src/Invoice_Gen.WebApi/Services/InvoiceService.cs
@@ -37,7 +37,7 @@ public class InvoiceService : IInvoiceService
             return returnData;
         }
     }
-    
+
     public InvoiceViewModel? GetById(int id)
     {
         using (_logger.BeginScope("{InvoiceService} getting invoice record for {ID}", nameof(InvoiceService), id))

--- a/tests/Invoice_Gen.WebApi.UnitTests/MapperTests/InvoiceViewModelMapperTests.cs
+++ b/tests/Invoice_Gen.WebApi.UnitTests/MapperTests/InvoiceViewModelMapperTests.cs
@@ -22,10 +22,21 @@ public class InvoiceViewModelMapperTests
         // Arrange
         var entity = new Invoice
         {
+            InvoiceId = 1,
             ClientId = _rng.Next(0, 200),
             DueDate = new DateTime(),
             IssueDate = new DateTime(),
             VatRate = _rng.Next(10, 25),
+            LineItems = new List<LineItem>
+            {
+                new()
+                {
+                    InvoiceId = 1,
+                    Cost = 10,
+                    Description = Guid.NewGuid().ToString(),
+                    Quantity = 1
+                }
+            }
         };
 
         // Act
@@ -38,6 +49,7 @@ public class InvoiceViewModelMapperTests
         Assert.Equal(vm.DueDate, entity.DueDate);
         Assert.Equal(vm.IssueDate, entity.IssueDate);
         Assert.Equal(vm.VatRate, entity.VatRate);
+        Assert.NotEmpty(vm.LineItems);
     }
 
     [Fact]

--- a/tests/Invoice_Gen.WebApi.UnitTests/RepoTests/InvoiceRepoTests.cs
+++ b/tests/Invoice_Gen.WebApi.UnitTests/RepoTests/InvoiceRepoTests.cs
@@ -37,7 +37,7 @@ public class InvoiceRepoTests
         Assert.IsAssignableFrom<List<Invoice>>(response);
         Assert.NotEmpty(response);
     }
-    
+
     [Fact]
     public async Task Add_AddsInstance_ToRepo()
     {
@@ -51,13 +51,13 @@ public class InvoiceRepoTests
             }
         };
         var invoiceListSet = DbSetHelpers.GetQueryableDbSet(invoiceList);
-    
+
         var mockedRepo = new Mock<IDbContext>();
         mockedRepo.Setup(s => s.Invoices).Returns(invoiceListSet.Object);
         var mockedLogger = new Mock<ILogger<InvoiceRepository>>();
-    
+
         var sut = new InvoiceRepository(mockedLogger.Object, mockedRepo.Object);
-    
+
         var invoiceToAdd = new Invoice
         {
             ClientId = 1,
@@ -65,14 +65,14 @@ public class InvoiceRepoTests
             IssueDate = new DateTime(2023, 06, 28),
             VatRate = 10
         };
-    
+
         // act
         var response = await sut.Add(invoiceToAdd);
-    
+
         // asset
         Assert.NotNull(response);
         Assert.IsAssignableFrom<Invoice>(response);
-    
+
         Assert.Equal(invoiceToAdd.ClientId, response.ClientId);
         Assert.Equal(invoiceToAdd.DueDate, response.DueDate);
         Assert.Equal(invoiceToAdd.IssueDate, response.IssueDate);

--- a/tests/Invoice_Gen.WebApi.UnitTests/RepoTests/InvoiceRepoTests.cs
+++ b/tests/Invoice_Gen.WebApi.UnitTests/RepoTests/InvoiceRepoTests.cs
@@ -1,0 +1,81 @@
+﻿using Invoice_Gen.WebApi.UnitTests.Helpers;
+using Microsoft.Extensions.Logging;
+
+namespace Invoice_Gen.WebApi.UnitTests.RepoTests;
+
+[ExcludeFromCodeCoverage]
+public class InvoiceRepoTests
+{
+    [Fact]
+    public void GetAll_Returns_ListOfInvoiceInstances()
+    {
+        // arrange
+        var invoiceList = new List<Invoice>
+        {
+            new()
+            {
+                InvoiceId = 1,
+                ClientId = 1,
+                DueDate = new DateTime(),
+                IssueDate = new DateTime(),
+                VatRate = 10
+            }
+        };
+        var invoiceListSet = DbSetHelpers.GetQueryableDbSet(invoiceList);
+
+        var mockedRepo = new Mock<IDbContext>();
+        mockedRepo.Setup(s => s.Invoices).Returns(invoiceListSet.Object);
+        var mockedLogger = new Mock<ILogger<InvoiceRepository>>();
+
+        var sut = new InvoiceRepository(mockedLogger.Object, mockedRepo.Object);
+
+        // act
+        var response = sut.GetAll();
+
+        // asset
+        Assert.NotNull(response);
+        Assert.IsAssignableFrom<List<Invoice>>(response);
+        Assert.NotEmpty(response);
+    }
+    
+    [Fact]
+    public async Task Add_AddsInstance_ToRepo()
+    {
+        // arrange
+        var invoiceList = new List<Invoice>
+        {
+            new()
+            {
+                InvoiceId = 1,
+                ClientId = 1,
+            }
+        };
+        var invoiceListSet = DbSetHelpers.GetQueryableDbSet(invoiceList);
+    
+        var mockedRepo = new Mock<IDbContext>();
+        mockedRepo.Setup(s => s.Invoices).Returns(invoiceListSet.Object);
+        var mockedLogger = new Mock<ILogger<InvoiceRepository>>();
+    
+        var sut = new InvoiceRepository(mockedLogger.Object, mockedRepo.Object);
+    
+        var invoiceToAdd = new Invoice
+        {
+            ClientId = 1,
+            DueDate = new DateTime(2024, 01, 01),
+            IssueDate = new DateTime(2023, 06, 28),
+            VatRate = 10
+        };
+    
+        // act
+        var response = await sut.Add(invoiceToAdd);
+    
+        // asset
+        Assert.NotNull(response);
+        Assert.IsAssignableFrom<Invoice>(response);
+    
+        Assert.Equal(invoiceToAdd.ClientId, response.ClientId);
+        Assert.Equal(invoiceToAdd.DueDate, response.DueDate);
+        Assert.Equal(invoiceToAdd.IssueDate, response.IssueDate);
+        Assert.Equal(invoiceToAdd.VatRate, response.VatRate);
+    }
+}

--- a/tests/Invoice_Gen.WebApi.UnitTests/RepoTests/LineItemRepoTests.cs
+++ b/tests/Invoice_Gen.WebApi.UnitTests/RepoTests/LineItemRepoTests.cs
@@ -1,0 +1,39 @@
+﻿using Invoice_Gen.WebApi.UnitTests.Helpers;
+using Microsoft.Extensions.Logging;
+
+namespace Invoice_Gen.WebApi.UnitTests.RepoTests;
+
+[ExcludeFromCodeCoverage]
+public class LineItemRepoTests
+{
+    [Fact]
+    public void GetAll_Returns_ListOfLineItemInstances()
+    {
+        // arrange
+        var lineItemList = new List<LineItem>
+        {
+            new()
+            {
+                InvoiceId = 1,
+                Cost = 100,
+                Description = Guid.NewGuid().ToString(),
+                Quantity = 1
+            }
+        };
+        var lineItemListSet = DbSetHelpers.GetQueryableDbSet(lineItemList);
+
+        var mockedRepo = new Mock<IDbContext>();
+        mockedRepo.Setup(s => s.LineItems).Returns(lineItemListSet.Object);
+        var mockedLogger = new Mock<ILogger<LineItemRepository>>();
+
+        var sut = new LineItemRepository(mockedLogger.Object, mockedRepo.Object);
+
+        // act
+        var response = sut.GetAll();
+
+        // asset
+        Assert.NotNull(response);
+        Assert.IsAssignableFrom<List<LineItem>>(response);
+        Assert.NotEmpty(response);
+    }
+}

--- a/tests/Invoice_Gen.WebApi.UnitTests/ServiceTests/InvoiceServiceTests.cs
+++ b/tests/Invoice_Gen.WebApi.UnitTests/ServiceTests/InvoiceServiceTests.cs
@@ -74,7 +74,7 @@ public class InvoiceServiceTests
         Assert.Equal(_issueDate, result.FirstOrDefault()?.IssueDate);
         Assert.Equal(_vatRate, result.FirstOrDefault()?.VatRate);
     }
-    
+
     [Fact]
     public void Given_A_Valid_InvoiceId_GetById_Should_Return_The_Matching_InvoiceViewModel()
     {

--- a/tests/Invoice_Gen.WebApi.UnitTests/ServiceTests/LineItemServiceTests.cs
+++ b/tests/Invoice_Gen.WebApi.UnitTests/ServiceTests/LineItemServiceTests.cs
@@ -1,0 +1,74 @@
+﻿using Invoice_Gen.WebApi.Services;
+using Microsoft.Extensions.Logging;
+
+namespace Invoice_Gen.WebApi.UnitTests.ServiceTests;
+
+[ExcludeFromCodeCoverage]
+public class LineItemServiceTests
+{
+    private readonly Random _rng;
+    private readonly int _lineItemId;
+    private readonly int _invoiceId;
+    private readonly int _cost;
+    private readonly string _description;
+    private readonly int _quantity;
+
+    private readonly Mock<IMapper<LineItemViewModel, LineItem>> _mockedLineItemViewModelMapper;
+
+    public LineItemServiceTests()
+    {
+        _rng = new Random();
+        _lineItemId = _rng.Next(1, 200);
+        _invoiceId = _rng.Next(1, 200);
+        _cost = _rng.Next(1, 200);
+        _description = Guid.NewGuid().ToString();
+        _quantity = _rng.Next(1, 25);
+
+        _mockedLineItemViewModelMapper = new Mock<IMapper<LineItemViewModel, LineItem>>();
+    }
+
+    [Fact]
+    public void Given_Atleast_One_LineItem_GetAll_Should_Return_At_Least_One_LineItemViewModel()
+    {
+        // Arrange
+        var entity = new LineItem
+        {
+            LineItemId = _lineItemId,
+            InvoiceId = _invoiceId,
+            Cost = _cost,
+            Description = _description,
+            Quantity = _quantity
+        };
+        var lineItemsForMock = new List<LineItem> { entity };
+
+        var mockedRepository = new Mock<ILineItemRepository>();
+        mockedRepository.Setup(x => x.GetAll()).Returns(lineItemsForMock);
+        var mockedLogger = new Mock<ILogger<LineItemService>>();
+
+        var expectedOutput = new LineItemViewModel
+        {
+            LineItemId = _lineItemId,
+            InvoiceId = _invoiceId,
+            Cost = _cost,
+            Description = _description,
+            Quantity = _quantity
+        };
+
+        _mockedLineItemViewModelMapper.Setup(x => x.Convert(entity)).Returns(expectedOutput);
+
+        var sut = new LineItemService(mockedLogger.Object, mockedRepository.Object, _mockedLineItemViewModelMapper.Object);
+
+        // Act
+        var result = sut.GetById(_lineItemId);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.IsAssignableFrom<LineItemViewModel>(result);
+
+        Assert.Equal(_lineItemId, result.LineItemId);
+        Assert.Equal(_invoiceId, result.InvoiceId);
+        Assert.Equal(_cost, result.Cost);
+        Assert.Equal(_description, result.Description);
+        Assert.Equal(_quantity, result.Quantity);
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds a new API endpoint `/Invoice` which returns all invoices in the following JSON format:

``` json
[
  {
    "invoiceId": 0,
    "clientId": 0,
    "dueDate": "2023-06-28T16:47:11.001Z",
    "issueDate": "2023-06-28T16:47:11.001Z",
    "vatRate": 0,
    "lineItems": [
      {
        "lineItemId": 0,
        "invoiceId": 0,
        "description": "string",
        "quantity": 0,
        "cost": 0
      }
    ]
  }
]
```

Also included in this PR are a number of small changes to the locations of classes and some more unit tests.
